### PR TITLE
Update to work with Fourmolu instead of ormolu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,14 +7,16 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
+      - ready_for_review
 jobs:
   build:
     strategy:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          # - macOS-latest
+          # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Disable core.autocrlf on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## Fourmolu action v1
 
-* Uses Fourmolu 0.5.0.1.
+* Uses Fourmolu 0.6.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,3 @@
-## Ormolu action v6
+## Fourmolu action v1
 
-* Uses Ormolu 0.5.0.0.
-
-## Ormolu action v5
-
-* Uses Ormolu 0.4.0.0.
-
-## Ormolu action v4
-
-* Uses Ormolu 0.3.0.1.
-* Added the new optional input `respect-cabal-files`.
-
-## Ormolu action v3
-
-* Uses Ormolu 0.2.0.0.
-
-## Ormolu action v2
-
-* Fixed the issue with the action hanging when the glob patterns match no
-  files. [Issue 3](https://github.com/mrkkrp/ormolu-action/issues/3).
-
-## Ormolu action v1
-
-* Initial release.
+* Uses Fourmolu 0.5.0.1.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,42 @@
-Copyright © 2020–present Mark Karpov
+This code was originally written by Mark Karpov for Ormolu:
+https://github.com/mrkkrp/ormolu-action.  The following is the
+license for that code:
+
+Copyright © 2020–2022 Mark Karpov
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name Mark Karpov nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS “AS IS” AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------
+
+The above repo has been updated to work with Fourmolu in this repository.
+This new code uses the following license:
+
+Copyright © 2022–present Bitnomial
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,74 @@
-# Ormolu action
+# Fourmolu action
 
-![CI](https://github.com/mrkkrp/ormolu-action/workflows/CI/badge.svg?branch=master)
+![CI](https://github.com/bitnomial/fourmolu-action/workflows/CI/badge.svg?branch=master)
 
-This is Ormolu action that helps to ensure that your Haskell project is
-formatted with [Ormolu][ormolu]. The action tries to find all Haskell source
-code files in your repository and fails if any of them is not formatted. In
+This Fourmolu Action helps to ensure that your Haskell project is
+formatted with [Fourmolu][fourmolu]. The action tries to find all Haskell source
+code files in your repository and fails if any of them are not formatted. In
 case of failure it prints the diff between the actual contents of the file
 and its formatted version.
 
-## Inputs
+## Example usage
 
-* `pattern` Glob pattern that are used to find source files to format. It is
-  possible to specify several patterns by putting each on a new line.
-* `respect-cabal-files` Whether to try to locate Cabal files and take into
-  account their `default-extensions` and `default-language` settings
-  (default: true).
-* `follow-symbolic-links` Whether to follow symbolic links (default: true).
-* `extra-args` Extra arguments to pass to Ormolu.
+In the simple case all you need to do is to add this step to your job:
+
+```yaml
+- uses: bitnomial/fourmolu-action@v1
+```
+
+The `@v1` after `fourmolu-action` should be replaced with the version of the
+Fourmolu Action you want to use.  See
+[Releases](https://github.com/bitnomial/fourmolu-action/releases) for all
+versions available.  Each version of the Fourmolu Action generally has a
+corresponding version of `fourmolu`.  Make sure you pick a Fourmolu Action
+version that uses the version of `fourmolu` you use locally.
+
+Here's a more complicated example that shows more options being used:
+
+```yaml
+- uses: bitnomial/fourmolu-action@v1
+  with:
+    # Only check the format of .hs in the src/ directory.
+    path: |
+      src/**/*.hs
+
+    # Don't follow symbolic links to .hs files.
+    follow-symbolic-links: false
+
+    # Extra args to pass to fourmolu on the command line.
+    extra-args: "--indent-wheres true"
+```
+
+## Example Usage with Build Matrix
+
+If you are using a build matrix, then it is more efficient to have a
+separate job for checking of formatting:
+
+```yaml
+jobs:
+  fourmolu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bitnomial/fourmolu-action@v6
+  build:
+    runs-on: ubuntu-latest
+    needs: fourmolu
+    ...
+```
+
+Here, the `build` job depends on `fourmolu` and will not run unless `fourmolu`
+passes.
+
+## Options
+
+The available options are defined in [`./action.yml`](./action.yml).  See that
+file for more explanation.
 
 ## Windows
 
 If you are running a workflow on Windows, be wary of [Git's
-`core.autocrlf`][git-core-autocrlf]. Ormolu always converts CRLF endings to
+`core.autocrlf`][git-core-autocrlf]. Fourmolu always converts CRLF endings to
 LF endings which may result in spurious diffs, so you probably want to
 disable `core.autocrlf`:
 
@@ -29,32 +76,5 @@ disable `core.autocrlf`:
 $ git config --global core.autocrlf false
 ```
 
-## Example usage
-
-In the simple case all you need to do is to add this step to your job:
-
-```yaml
-- uses: mrkkrp/ormolu-action@v6
-```
-
-However, if you are using a matrix, then it is more efficient to have a
-separate job for checking of formatting:
-
-```yaml
-jobs:
-  ormolu:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: mrkkrp/ormolu-action@v6
-  build:
-    runs-on: ubuntu-latest
-    needs: ormolu
-    ...
-```
-
-Here, the `build` job depends on `ormolu` and will not run unless `ormolu`
-passes.
-
-[ormolu]: https://github.com/tweag/ormolu
+[fourmolu]: https://github.com/fourmolu/fourmolu
 [git-core-autocrlf]: https://www.git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf

--- a/README.md
+++ b/README.md
@@ -76,5 +76,38 @@ disable `core.autocrlf`:
 $ git config --global core.autocrlf false
 ```
 
+## Hacking on this repo
+
+In order to do development on this repo, you first need to install NodeJS and
+`npm` to your system.  This has been confirmed to work with the following
+versions, but newer (or slightly older) versions may work as well:
+
+- **NodeJS**: 14.19.1
+- **`npm`**: 6.14.16
+
+Next, clone this repo:
+
+```console
+$ git clone git@github.com:bitnomial/fourmolu-action.git
+```
+
+Then, within this repo, install all dependencies defined in `package.json`:
+
+```console
+$ npm install
+```
+
+Now, you should be setup to start development.  Development consists of hacking
+on the [`./index.js`](./index.js) file.  After making changes to this file,
+you'll need to regenerate the files in [`./dist/`](./dist).  You can do that
+with the following command:
+
+```console
+$ npm run prepare
+```
+
+When sending a PR, make sure to run `npm run prepare` and commit the changes
+to `./dist` whenever you make a change in `./index.js`.
+
 [fourmolu]: https://github.com/fourmolu/fourmolu
 [git-core-autocrlf]: https://www.git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf

--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,6 @@ inputs:
     default: |
       **/*.hs
       **/*.hs-boot
-  respect-cabal-files:
-    required: false
-    description: >
-      Whether to try to locate Cabal files and take into account their
-      default-extensions and default-language settings.
-    default: true
   follow-symbolic-links:
     required: false
     description: >

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'ormolu-action'
-description: 'Check formatting of Haskell code with Ormolu'
+name: 'fourmolu-action'
+description: 'Check formatting of Haskell code with Fourmolu'
 inputs:
   pattern:
     required: false
@@ -23,7 +23,7 @@ inputs:
   extra-args:
     required: false
     description: >
-      Extra arguments to pass to Ormolu.
+      Extra arguments to pass to Fourmolu.
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,6 +9,9 @@ module.exports =
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(5622);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(5747);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+
 
 
 const core = __webpack_require__(2186);
@@ -17,51 +20,63 @@ const tool_cache = __webpack_require__(7784);
 const exec = __webpack_require__(1514);
 const glob = __webpack_require__(8090);
 
-const ormolu_version = '0.5.0.0';
-const ormolu_linux_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Linux.zip';
-const ormolu_windows_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Windows.zip';
-const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-macOS.zip';
+const fourmolu_version = '0.6.0.0';
+
+// XXX: These release binaries appear to be dynamically linked, so they may not
+// run on some systems.
+const fourmolu_linux_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-linux-x86_64';
+
+// TODO: As of this writing, there are no Windows or MacOSX binaries available
+// for fourmolu. However, according to
+// https://brandonchinn178.github.io/blog/2022/05/19/automating-fourmolu-releases-with-github-actions.html,
+// they should be available from the next release.  We may need to change these URLs
+// when the actual binaries are available.
+//const fourmolu_windows_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-windows-x86_64';
+//const fourmolu_macos_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-darwin-x86_64';
 
 const input_pattern = core.getInput('pattern');
-const input_respect_cabal_files = core.getInput('respect-cabal-files').toUpperCase() !== 'FALSE';
 const input_follow_symbolic_links = core.getInput('follow-symbolic-links').toUpperCase() !== 'FALSE';
 const input_extra_args = core.getInput('extra-args');
 
 async function run() {
   try {
 
-    // Download ormolu archive
+    // Download fourmolu binary
 
-    var ormolu_archive;
+    var fourmolu_downloaded_binary;
 
-    if (process.platform === 'win32') {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_windows_url);
+
+    if (process.platform === 'linux') {
+        fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_linux_url);
     }
-    else if (process.platform === 'darwin') {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_macos_url);
-    }
+    // else if (process.platform === 'darwin') {
+    //     fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_macos_url);
+    // }
+    // else if (process.platform === 'win32') {
+    //     fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_windows_url);
+    // }
     else {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_linux_url);
+        core.setFailed("no fourmolu binary found for platform: " + process.platform);
     }
 
-    // Unpack the archive
+    // At this point, fourmolu_downloaded_binary is the fourmolu binary we just
+    // downloaded, but tool_cache.downloadTool() gives it a random UUID as a
+    // name.  We rename it to `fourmolu` here.
+    const fourmolu_binary = path__WEBPACK_IMPORTED_MODULE_0__.join(path__WEBPACK_IMPORTED_MODULE_0__.dirname(fourmolu_downloaded_binary), 'fourmolu');
+    fs__WEBPACK_IMPORTED_MODULE_1__.renameSync(fourmolu_downloaded_binary, fourmolu_binary)
 
-    const ormolu_extracted_dir = process.env['RUNNER_TEMP'];
-    await tool_cache.extractZip(ormolu_archive, ormolu_extracted_dir);
-    // const ormolu_extracted_path = path.join(ormolu_extracted_dir, 'ormolu');
+    // Cache fourmolu executable
 
-    // Cache ormolu executable
-
-    const ormolu_cached_dir = await tool_cache.cacheDir(
-        ormolu_extracted_dir,
-        'ormolu',
-        ormolu_version
+    const fourmolu_cached_dir = await tool_cache.cacheDir(
+        path__WEBPACK_IMPORTED_MODULE_0__.dirname(fourmolu_binary),
+        'fourmolu',
+        fourmolu_version
     );
-    const ormolu_cached_path = path__WEBPACK_IMPORTED_MODULE_0__.join(ormolu_cached_dir, 'ormolu');
+    const fourmolu_cached_path = path__WEBPACK_IMPORTED_MODULE_0__.join(fourmolu_cached_dir, 'fourmolu');
 
     // Set mode
 
-    exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
+    exec.exec('chmod', ['+x', fourmolu_cached_path], {silent: true});
 
     // Glob for the files to format
 
@@ -81,23 +96,14 @@ async function run() {
         extra_args = input_extra_args.split(' ');
     }
 
-    // Respect Cabal files
+    // Run fourmolu
 
-    var respect_cabal_files = [];
-
-    if (!(input_respect_cabal_files)) {
-        respect_cabal_files = ['--no-cabal'];
-    }
-
-    // Run ormolu
-
-    await exec.exec(ormolu_cached_path, ['--version']);
+    await exec.exec(fourmolu_cached_path, ['--version']);
 
     if (files.length > 0) {
         await exec.exec(
-            ormolu_cached_path,
+            fourmolu_cached_path,
             ['--color', 'always', '--check-idempotence', '--mode', 'check']
-                .concat(respect_cabal_files)
                 .concat(extra_args)
                 .concat(files)
         );
@@ -107,7 +113,7 @@ async function run() {
     }
 
   } catch (error) {
-    core.setFailed("Ormolu detected unformatted files");
+    core.setFailed("fourmolu detected unformatted files");
   }
 }
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,8 @@
+indentation: 4
+comma-style: leading # for lists, tuples etc. - can also be 'trailing'
+record-brace-space: false # rec {x = 1} vs. rec{x = 1}
+indent-wheres: true # 'false' means save space by only half-indenting the 'where' keyword
+diff-friendly-import-export: true # 'false' uses Ormolu-style lists
+respectful: true # don't be too opinionated about newlines etc.
+haddock-style: single-line # '--' vs. '{-'
+newlines-between-decls: 2

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 
 const core = require('@actions/core');
 const github = require('@actions/github');
@@ -6,51 +7,63 @@ const tool_cache = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const glob = require('@actions/glob');
 
-const ormolu_version = '0.5.0.0';
-const ormolu_linux_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Linux.zip';
-const ormolu_windows_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Windows.zip';
-const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-macOS.zip';
+const fourmolu_version = '0.6.0.0';
+
+// XXX: These release binaries appear to be dynamically linked, so they may not
+// run on some systems.
+const fourmolu_linux_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-linux-x86_64';
+
+// TODO: As of this writing, there are no Windows or MacOSX binaries available
+// for fourmolu. However, according to
+// https://brandonchinn178.github.io/blog/2022/05/19/automating-fourmolu-releases-with-github-actions.html,
+// they should be available from the next release.  We may need to change these URLs
+// when the actual binaries are available.
+//const fourmolu_windows_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-windows-x86_64';
+//const fourmolu_macos_url = 'https://github.com/fourmolu/fourmolu/releases/download/v' + fourmolu_version + '/fourmolu-' + fourmolu_version + '-darwin-x86_64';
 
 const input_pattern = core.getInput('pattern');
-const input_respect_cabal_files = core.getInput('respect-cabal-files').toUpperCase() !== 'FALSE';
 const input_follow_symbolic_links = core.getInput('follow-symbolic-links').toUpperCase() !== 'FALSE';
 const input_extra_args = core.getInput('extra-args');
 
 async function run() {
   try {
 
-    // Download ormolu archive
+    // Download fourmolu binary
 
-    var ormolu_archive;
+    var fourmolu_downloaded_binary;
 
-    if (process.platform === 'win32') {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_windows_url);
+
+    if (process.platform === 'linux') {
+        fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_linux_url);
     }
-    else if (process.platform === 'darwin') {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_macos_url);
-    }
+    // else if (process.platform === 'darwin') {
+    //     fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_macos_url);
+    // }
+    // else if (process.platform === 'win32') {
+    //     fourmolu_downloaded_binary = await tool_cache.downloadTool(fourmolu_windows_url);
+    // }
     else {
-        ormolu_archive = await tool_cache.downloadTool(ormolu_linux_url);
+        core.setFailed("no fourmolu binary found for platform: " + process.platform);
     }
 
-    // Unpack the archive
+    // At this point, fourmolu_downloaded_binary is the fourmolu binary we just
+    // downloaded, but tool_cache.downloadTool() gives it a random UUID as a
+    // name.  We rename it to `fourmolu` here.
+    const fourmolu_binary = path.join(path.dirname(fourmolu_downloaded_binary), 'fourmolu');
+    fs.renameSync(fourmolu_downloaded_binary, fourmolu_binary)
 
-    const ormolu_extracted_dir = process.env['RUNNER_TEMP'];
-    await tool_cache.extractZip(ormolu_archive, ormolu_extracted_dir);
-    // const ormolu_extracted_path = path.join(ormolu_extracted_dir, 'ormolu');
+    // Cache fourmolu executable
 
-    // Cache ormolu executable
-
-    const ormolu_cached_dir = await tool_cache.cacheDir(
-        ormolu_extracted_dir,
-        'ormolu',
-        ormolu_version
+    const fourmolu_cached_dir = await tool_cache.cacheDir(
+        path.dirname(fourmolu_binary),
+        'fourmolu',
+        fourmolu_version
     );
-    const ormolu_cached_path = path.join(ormolu_cached_dir, 'ormolu');
+    const fourmolu_cached_path = path.join(fourmolu_cached_dir, 'fourmolu');
 
     // Set mode
 
-    exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
+    exec.exec('chmod', ['+x', fourmolu_cached_path], {silent: true});
 
     // Glob for the files to format
 
@@ -70,23 +83,14 @@ async function run() {
         extra_args = input_extra_args.split(' ');
     }
 
-    // Respect Cabal files
+    // Run fourmolu
 
-    var respect_cabal_files = [];
-
-    if (!(input_respect_cabal_files)) {
-        respect_cabal_files = ['--no-cabal'];
-    }
-
-    // Run ormolu
-
-    await exec.exec(ormolu_cached_path, ['--version']);
+    await exec.exec(fourmolu_cached_path, ['--version']);
 
     if (files.length > 0) {
         await exec.exec(
-            ormolu_cached_path,
+            fourmolu_cached_path,
             ['--color', 'always', '--check-idempotence', '--mode', 'check']
-                .concat(respect_cabal_files)
                 .concat(extra_args)
                 .concat(files)
         );
@@ -96,7 +100,7 @@ async function run() {
     }
 
   } catch (error) {
-    core.setFailed("Ormolu detected unformatted files");
+    core.setFailed("fourmolu detected unformatted files");
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ormolu-action",
   "version": "1.0.0",
-  "description": "Check formatting of Haskell code with Ormolu.",
+  "description": "Check formatting of Haskell code with Fourmolu.",
   "main": "index.js",
   "scripts": {
     "prepare": "ncc build index.js -o dist",
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrkkrp/ormolu-action.git"
+    "url": "git+https://github.com/bitnomial/fourmolu-action.git"
   },
   "keywords": [
     "foramtter",
     "haskell"
   ],
-  "author": "Mark Karpov",
+  "author": "original: Mark Karpov, fourmolu port: Bitnomial",
   "license": "BSD 3 clause",
   "dependencies": {
     "@actions/core": "^1.2.6",
@@ -26,10 +26,10 @@
     "@vercel/ncc": "^0.24.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.24.0"
+    "@vercel/ncc": "^0.24.1"
   },
   "bugs": {
-    "url": "https://github.com/mrkkrp/ormolu-action/issues"
+    "url": "https://github.com/bitnomial/fourmolu-action/issues"
   },
-  "homepage": "https://github.com/mrkkrp/ormolu-action#readme"
+  "homepage": "https://github.com/bitnomial/fourmolu-action#readme"
 }

--- a/test-code/Main.hs
+++ b/test-code/Main.hs
@@ -1,12 +1,20 @@
 module Main (main) where
 
+
+-- This is an example Haskell file.  The CI for this repo will run the Fourmolu
+-- GitHub Action defined in this repo on this file.  If you want to check that
+-- this repo is working correctly, make some changes to this file, commit, and
+-- send a PR.  A GitHub Action should run, and then fail.
+
 main :: IO ()
 main =
-           do
-            print [ "hello",
-               "bad",   "good",
-
-                      "bye" ]
-            pure ()
-      where
-  x = 1
+    do
+        print
+            [ "hello"
+            , "bad"
+            , "good"
+            , "bye"
+            ]
+        pure ()
+    where
+        x = 1

--- a/test-code/Main.hs
+++ b/test-code/Main.hs
@@ -1,4 +1,12 @@
 module Main (main) where
 
 main :: IO ()
-main = return ()
+main =
+           do
+            print [ "hello",
+               "bad",   "good",
+
+                      "bye" ]
+            pure ()
+      where
+  x = 1


### PR DESCRIPTION
This PR converts this repo use to `fourmolu` instead of `ormolu`.

When reviewing this PR, the main changes to look at are in `./index.js`.

Here's an example of this action running, and showing errors for incorrectly formatted Haskell code: https://github.com/bitnomial/fourmolu-action/runs/6622929855?check_suite_focus=true